### PR TITLE
Conform thread message types to the registry (location + battery)

### DIFF
--- a/components/input/BatteryComponent.js
+++ b/components/input/BatteryComponent.js
@@ -6,6 +6,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { MessageContext } from '../../services/store/messageStore';
 import fetchJson from '../../services/fetchJson';
 import constants from '../../constants/constants';
+import { buildBatteryMetric } from '../../services/messageTypes';
 
 let batteryColor = (level) => {
   let round = batteryPercentage(level);
@@ -29,7 +30,7 @@ const BatteryComponent = (props) => {
 
   let sendBattery = async (props, dispatch) => {
     try {
-      const newMessage = { body: { battery: battery } };
+      const newMessage = { body: buildBatteryMetric(battery) };
       const data = await fetchJson.POST(
         newMessage,
         constants.createNewMessage(props.threadId)

--- a/components/input/LocationComponent.js
+++ b/components/input/LocationComponent.js
@@ -7,6 +7,7 @@ import constants from '../../constants/constants';
 import fetchJson from '../../services/fetchJson';
 
 import { MessageContext } from '../../services/store/messageStore';
+import { buildLocation } from '../../services/messageTypes';
 
 let sendLocation = async (props, dispatch) => {
   const hasLocationServicesEnabled = await Location.hasServicesEnabledAsync();
@@ -26,7 +27,9 @@ let sendLocation = async (props, dispatch) => {
     }
 
     let location = await Location.getCurrentPositionAsync({});
-    const newMessage = { body: [location] };
+    const newMessage = {
+      body: buildLocation(location.coords.latitude, location.coords.longitude),
+    };
 
     const data = await fetchJson.POST(
       newMessage,

--- a/docs/plans/2026-07-17-thread-message-types-design.md
+++ b/docs/plans/2026-07-17-thread-message-types-design.md
@@ -1,0 +1,95 @@
+# Design: Conform thread-screen message types to the registry (location + battery)
+
+Date: 2026-07-17
+Branch: `feature/thread-message-types` (stacked on `feature/expo-sdk-upgrade`)
+Status: Approved (design phase)
+
+## Problem
+
+The thread screen (`screens/MessageScreen.js`) composes non-conforming, ad-hoc
+message bodies:
+
+- "Random Numbers" button → `{ body: [n1, n2] }` (test artifact)
+- `LocationComponent` → `{ body: [<raw expo-location object>] }`
+- `BatteryComponent` → `{ body: { battery: 45 } }`
+
+None match the Swinn message-type registry (the contract). The renderer
+(`renderRow`) just dumps `JSON.stringify(message.body)` with a `//TO-DO parse
+messages` note.
+
+## Contract
+
+The registry is the contract. A message `body` is a self-describing instance of a
+registry type:
+
+```json
+{ "type": "<type>", "version": "<version>", "payload": { ...validates against schema... } }
+```
+
+Two types are in scope:
+
+- **location** (`renderer_hint: LocationPin`) — payload `{ lat: -90..90, lng: -180..180 }`
+- **metric** (`renderer_hint: MetricDisplay`) — payload
+  `{ quantity: "battery_level", value, unit: "percent", recorded_at? }`;
+  the registry constrains `battery_level` to the `percent` unit.
+
+## Scope
+
+Minimal: fix `location` and `battery` (as a `metric`), remove the random-numbers
+artifact. Other types are out of scope and continue to render as raw JSON. No
+renderer cards (that was the declined "render all 7" scope).
+
+## Approach (A — small pure module, kept unopinionated)
+
+New module `services/messageTypes.js` with two pure builders that emit the
+canonical body and validate only what the schema/constraints require:
+
+```js
+// { type: 'location', version: '1.0', payload: { lat, lng } }
+export function buildLocation(lat, lng);      // throws if lat/lng not numbers in range
+
+// { type: 'metric', version: '1.0', payload: { quantity: 'battery_level', value, unit: 'percent' } }
+export function buildBatteryMetric(value);    // throws if value not a number in [0,100]
+```
+
+No validation beyond conformance (required fields, numeric ranges, the
+`battery_level → percent` unit constraint). Version is `'1.0'` per the registry.
+Pure functions → unit-testable without a device.
+
+Rejected: inline shaping in each composer (validation scattered/untestable); a
+generic JSON-Schema validator for all 7 types (new dependency, YAGNI).
+
+## Component changes
+
+- `components/input/LocationComponent.js`: read `coords.latitude`/`coords.longitude`
+  from `expo-location`, POST `{ body: buildLocation(lat, lng) }`.
+- `components/input/BatteryComponent.js`: convert battery level (0–1) to a percent
+  integer, POST `{ body: buildBatteryMetric(value) }`.
+- `screens/MessageScreen.js`: remove the "Random Numbers" button and its
+  `handleNewMessage`. Renderer unchanged (now shows canonical `{type,version,payload}`).
+
+## Error handling
+
+Builders throw on invalid input; composers catch and `alert()` / log (matching the
+existing permission/error handling in those components). A malformed reading never
+reaches the API.
+
+## Testing
+
+`services/messageTypes.test.cjs` — Babel-transform + `node:assert` (the project's
+established no-jest pattern):
+
+- `buildLocation(52.5, 13.4)` deep-equals the exact canonical location object.
+- `buildLocation` throws for out-of-range / non-number lat or lng.
+- `buildBatteryMetric(87)` deep-equals the exact canonical metric object
+  (`quantity: 'battery_level'`, `unit: 'percent'`).
+- `buildBatteryMetric` throws for value < 0, > 100, or non-number.
+
+Runtime check: send a location and a battery from the thread screen, confirm the
+POST body is the canonical shape and the message renders (as canonical JSON).
+
+## Out of scope
+
+- Composers/renderers for the other 5 types (currency, status, file_reference, mood, ping).
+- Renderer cards / renderer_hint → component mapping.
+- Fetching the registry from the backend (the two entries are used directly).

--- a/docs/plans/2026-07-17-thread-message-types-implementation.md
+++ b/docs/plans/2026-07-17-thread-message-types-implementation.md
@@ -1,0 +1,256 @@
+# Thread Message Types Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the thread screen's location and battery messages conform to the Swinn type registry (`{ type, version, payload }`), and drop the non-conforming "Random Numbers" test button.
+
+**Architecture:** From `docs/plans/2026-07-17-thread-message-types-design.md` (Approach A). A small pure module `services/messageTypes.js` exposes `buildLocation` / `buildBatteryMetric` that return the canonical body and validate only what the registry schema/constraints require. The two composer components call these; the renderer is untouched.
+
+**Tech Stack:** Expo SDK 57 / React Native, `expo-location`, `expo-battery`. No jest — pure functions are tested with a Babel-transform + `node:assert` script (the pattern used by `config/env.test.cjs`).
+
+**Branch:** `feature/thread-message-types` (stacked on `feature/expo-sdk-upgrade`) — stay on it.
+
+**Node:** run `eval "$(fnm env)" && fnm use 22` before any node command.
+
+---
+
+### Task 1: `services/messageTypes.js` (TDD)
+
+**Files:**
+- Create: `services/messageTypes.js`
+- Test: `services/messageTypes.test.cjs`
+
+**Step 1: Write the failing test** — `services/messageTypes.test.cjs`
+
+```js
+const assert = require('node:assert');
+const { transformFileSync } = require('@babel/core');
+
+const { code } = transformFileSync('services/messageTypes.js', { presets: ['babel-preset-expo'] });
+const mod = { exports: {} };
+new Function('module', 'exports', code)(mod, mod.exports);
+const { buildLocation, buildBatteryMetric } = mod.exports;
+
+// location — valid
+assert.deepStrictEqual(
+  buildLocation(52.5, 13.4),
+  { type: 'location', version: '1.0', payload: { lat: 52.5, lng: 13.4 } }
+);
+// location — invalid
+assert.throws(() => buildLocation(91, 0), /lat/);
+assert.throws(() => buildLocation(0, 181), /lng/);
+assert.throws(() => buildLocation('x', 0));
+assert.throws(() => buildLocation(0, NaN));
+
+// metric (battery) — valid
+assert.deepStrictEqual(
+  buildBatteryMetric(87),
+  { type: 'metric', version: '1.0', payload: { quantity: 'battery_level', value: 87, unit: 'percent' } }
+);
+// metric — invalid
+assert.throws(() => buildBatteryMetric(-1));
+assert.throws(() => buildBatteryMetric(101));
+assert.throws(() => buildBatteryMetric('x'));
+
+console.log('messageTypes OK');
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `eval "$(fnm env)" && fnm use 22 && node services/messageTypes.test.cjs`
+Expected: FAIL — `services/messageTypes.js` does not exist (transformFileSync throws ENOENT).
+
+**Step 3: Write minimal implementation** — `services/messageTypes.js`
+
+```js
+// Canonical builders for Swinn message bodies. Each returns { type, version,
+// payload } where payload validates against the registry schema. Validation is
+// limited to what the schema/constraints require — no extra opinions.
+
+function isFiniteNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+
+// location: payload { lat: -90..90, lng: -180..180 }
+export function buildLocation(lat, lng) {
+  if (!isFiniteNumber(lat) || lat < -90 || lat > 90) {
+    throw new Error(`Invalid location lat: ${lat}`);
+  }
+  if (!isFiniteNumber(lng) || lng < -180 || lng > 180) {
+    throw new Error(`Invalid location lng: ${lng}`);
+  }
+  return { type: 'location', version: '1.0', payload: { lat, lng } };
+}
+
+// metric battery_level: unit is constrained to 'percent' by the registry
+export function buildBatteryMetric(value) {
+  if (!isFiniteNumber(value) || value < 0 || value > 100) {
+    throw new Error(`Invalid battery value: ${value}`);
+  }
+  return {
+    type: 'metric',
+    version: '1.0',
+    payload: { quantity: 'battery_level', value, unit: 'percent' },
+  };
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `eval "$(fnm env)" && fnm use 22 && node services/messageTypes.test.cjs`
+Expected: `messageTypes OK`
+
+**Step 5: Commit**
+
+```bash
+git add services/messageTypes.js services/messageTypes.test.cjs
+git commit -m "Add canonical message builders for location and battery metric"
+```
+Include trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 2: `LocationComponent` emits canonical location
+
+**Files:**
+- Modify: `components/input/LocationComponent.js`
+
+**Step 1: Import the builder** — add near the other imports:
+```js
+import { buildLocation } from '../../services/messageTypes';
+```
+
+**Step 2: Replace the body construction** — in `sendLocation`, change:
+```js
+    let location = await Location.getCurrentPositionAsync({});
+    const newMessage = { body: [location] };
+```
+to:
+```js
+    let location = await Location.getCurrentPositionAsync({});
+    const newMessage = {
+      body: buildLocation(location.coords.latitude, location.coords.longitude),
+    };
+```
+Leave the surrounding `try/catch` as-is (a thrown validation error is caught and logged there).
+
+**Step 3: Verify it parses**
+
+Run: `eval "$(fnm env)" && fnm use 22 && node -e "require('@babel/core').transformFileSync('components/input/LocationComponent.js',{presets:['babel-preset-expo']}); console.log('OK')"`
+Expected: `OK`
+
+**Step 4: Commit**
+
+```bash
+git add components/input/LocationComponent.js
+git commit -m "LocationComponent: emit canonical location message body"
+```
+Include the Co-Authored-By trailer.
+
+---
+
+### Task 3: `BatteryComponent` emits canonical metric
+
+**Files:**
+- Modify: `components/input/BatteryComponent.js`
+
+**Step 1: Import the builder**:
+```js
+import { buildBatteryMetric } from '../../services/messageTypes';
+```
+
+**Step 2: Replace the body construction** — in `sendBattery`, change:
+```js
+      const newMessage = { body: { battery: battery } };
+```
+to:
+```js
+      const newMessage = { body: buildBatteryMetric(battery) };
+```
+> `battery` state is already a 0–100 percentage (`batteryPercentage(level)` = `Math.round(level*100)`), which is what `buildBatteryMetric` expects.
+
+**Step 3: Verify it parses**
+
+Run: `eval "$(fnm env)" && fnm use 22 && node -e "require('@babel/core').transformFileSync('components/input/BatteryComponent.js',{presets:['babel-preset-expo']}); console.log('OK')"`
+Expected: `OK`
+
+**Step 4: Commit**
+
+```bash
+git add components/input/BatteryComponent.js
+git commit -m "BatteryComponent: emit canonical metric (battery_level) message body"
+```
+Include the Co-Authored-By trailer.
+
+---
+
+### Task 4: Remove the "Random Numbers" test button
+
+**Files:**
+- Modify: `screens/MessageScreen.js`
+
+**Step 1: Delete `handleNewMessage`** — remove the entire function (the `ranNum1/ranNum2` random-number generator and its POST), lines ~72–95.
+
+**Step 2: Delete the button** — in the JSX `<HStack>` at the bottom, remove:
+```jsx
+            <Button
+              flex={1}
+              style={{ backgroundColor: '#F2786D' }}
+              onPress={handleNewMessage}
+            >
+              <Ionicons name='cellular' color='#fff' size={18} />
+              <ButtonText color='#fff'> Random Numbers</ButtonText>
+            </Button>
+```
+Keep `<LocationComponent threadId={threadId} />` and `<BatteryComponent threadId={threadId} />`.
+
+**Step 3: Remove now-unused imports** — if `Button`, `ButtonText`, or `Ionicons` are no longer referenced anywhere else in the file, remove them from the imports. (Verify with a grep before deleting; `Ionicons` is likely only used here.)
+
+Run: `grep -nE "Ionicons|ButtonText|<Button" screens/MessageScreen.js`
+
+**Step 4: Verify it parses**
+
+Run: `eval "$(fnm env)" && fnm use 22 && node -e "require('@babel/core').transformFileSync('screens/MessageScreen.js',{presets:['babel-preset-expo']}); console.log('OK')"`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add screens/MessageScreen.js
+git commit -m "Remove non-conforming Random Numbers test button from thread screen"
+```
+Include the Co-Authored-By trailer.
+
+---
+
+### Task 5: Runtime verification
+
+**Files:** none modified.
+
+**Step 1: Re-run the unit test** (guards against regressions):
+Run: `eval "$(fnm env)" && fnm use 22 && node services/messageTypes.test.cjs`
+Expected: `messageTypes OK`
+
+**Step 2: Drive the thread screen** — start the app (dev client or web), open a thread, and:
+- Tap **Location** → confirm the POSTed body is `{ type: 'location', version: '1.0', payload: { lat, lng } }` (check the network request or the message that renders).
+- Tap **Battery** → confirm the body is `{ type: 'metric', version: '1.0', payload: { quantity: 'battery_level', value, unit: 'percent' } }`.
+- Confirm the "Random Numbers" button is gone.
+
+> The renderer still shows `JSON.stringify(body)`, so the canonical object appears directly in the thread — that is the expected visual for this minimal PR.
+
+**Step 3: Report** — unit test green, both composers emit canonical bodies, random button removed.
+
+---
+
+## Done criteria
+
+- `node services/messageTypes.test.cjs` passes.
+- Location and battery messages POST canonical `{ type, version, payload }` bodies validated against the registry (incl. `battery_level → percent`).
+- The "Random Numbers" button and `handleNewMessage` are gone; no dead imports left.
+- All four source files parse under `babel-preset-expo`.
+
+## Follow-ups (out of scope)
+
+- Composers/renderers for the other 5 registry types.
+- `renderer_hint` → card component mapping (LocationPin, MetricDisplay, …).
+- Fetching the registry from the backend instead of using the two entries directly.

--- a/screens/MessageScreen.js
+++ b/screens/MessageScreen.js
@@ -7,10 +7,7 @@ import {
   Avatar,
   AvatarImage,
   Text,
-  Button,
-  ButtonText,
 } from '@gluestack-ui/themed';
-import { Ionicons } from '@expo/vector-icons';
 import { StyleSheet } from 'react-native';
 
 import constants from '../constants/constants';
@@ -69,31 +66,6 @@ const MessageScreen = (props) => {
     }
   };
 
-  const handleNewMessage = async () => {
-    try {
-      //generate random number between -100 and 100 for test purposes
-      var ranNum1 =
-        Math.ceil(Math.random() * 100) * (Math.round(Math.random()) ? 1 : -1);
-      var ranNum2 =
-        Math.ceil(Math.random() * 100) * (Math.round(Math.random()) ? 1 : -1);
-
-      const newMessage = { body: [ranNum1, ranNum2] };
-
-      const data = await fetchJson.POST(
-        newMessage,
-        constants.createNewMessage(threadId)
-      );
-
-      try {
-        await dispatch({ type: 'ADD_MESSAGES', data: data.data });
-      } catch (err) {
-        console.log('ERROR => ', err);
-      }
-    } catch (error) {
-      console.log('Message Retrieve Error:', error);
-    }
-  };
-
   const renderRow = (message) => {
     //TO-DO parse messages
     return (
@@ -125,14 +97,6 @@ const MessageScreen = (props) => {
             ))}
           </ScrollView>
           <HStack>
-            <Button
-              flex={1}
-              style={{ backgroundColor: '#F2786D' }}
-              onPress={handleNewMessage}
-            >
-              <Ionicons name='cellular' color='#fff' size={18} />
-              <ButtonText color='#fff'> Random Numbers</ButtonText>
-            </Button>
             <LocationComponent threadId={threadId} />
             <BatteryComponent threadId={threadId} />
           </HStack>

--- a/services/messageTypes.js
+++ b/services/messageTypes.js
@@ -1,0 +1,30 @@
+// Canonical builders for Swinn message bodies. Each returns { type, version,
+// payload } where payload validates against the registry schema. Validation is
+// limited to what the schema/constraints require — no extra opinions.
+
+function isFiniteNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+
+// location: payload { lat: -90..90, lng: -180..180 }
+export function buildLocation(lat, lng) {
+  if (!isFiniteNumber(lat) || lat < -90 || lat > 90) {
+    throw new Error(`Invalid location lat: ${lat}`);
+  }
+  if (!isFiniteNumber(lng) || lng < -180 || lng > 180) {
+    throw new Error(`Invalid location lng: ${lng}`);
+  }
+  return { type: 'location', version: '1.0', payload: { lat, lng } };
+}
+
+// metric battery_level: unit is constrained to 'percent' by the registry
+export function buildBatteryMetric(value) {
+  if (!isFiniteNumber(value) || value < 0 || value > 100) {
+    throw new Error(`Invalid battery value: ${value}`);
+  }
+  return {
+    type: 'metric',
+    version: '1.0',
+    payload: { quantity: 'battery_level', value, unit: 'percent' },
+  };
+}

--- a/services/messageTypes.test.cjs
+++ b/services/messageTypes.test.cjs
@@ -1,0 +1,30 @@
+const assert = require('node:assert');
+const { transformFileSync } = require('@babel/core');
+
+const { code } = transformFileSync('services/messageTypes.js', { presets: ['babel-preset-expo'] });
+const mod = { exports: {} };
+new Function('module', 'exports', code)(mod, mod.exports);
+const { buildLocation, buildBatteryMetric } = mod.exports;
+
+// location — valid
+assert.deepStrictEqual(
+  buildLocation(52.5, 13.4),
+  { type: 'location', version: '1.0', payload: { lat: 52.5, lng: 13.4 } }
+);
+// location — invalid
+assert.throws(() => buildLocation(91, 0), /lat/);
+assert.throws(() => buildLocation(0, 181), /lng/);
+assert.throws(() => buildLocation('x', 0));
+assert.throws(() => buildLocation(0, NaN));
+
+// metric (battery) — valid
+assert.deepStrictEqual(
+  buildBatteryMetric(87),
+  { type: 'metric', version: '1.0', payload: { quantity: 'battery_level', value: 87, unit: 'percent' } }
+);
+// metric — invalid
+assert.throws(() => buildBatteryMetric(-1));
+assert.throws(() => buildBatteryMetric(101));
+assert.throws(() => buildBatteryMetric('x'));
+
+console.log('messageTypes OK');


### PR DESCRIPTION
## Summary

Makes the thread screen's message bodies conform to the Swinn message-type registry (`{ type, version, payload }`, payload validated against the type schema), replacing ad-hoc shapes. Minimal scope: **location** and **battery**; other types are out of scope.

- **`services/messageTypes.js`** — new pure builders `buildLocation(lat, lng)` and `buildBatteryMetric(value)` returning the exact canonical bodies, validating only what the registry schema/constraints require (lat/lng ranges; `battery_level → percent`).
- **LocationComponent** → posts `{ type: 'location', version: '1.0', payload: { lat, lng } }` (was the raw expo-location object).
- **BatteryComponent** → posts `{ type: 'metric', version: '1.0', payload: { quantity: 'battery_level', value, unit: 'percent' } }` (was `{ battery }`).
- **MessageScreen** — removed the non-conforming "Random Numbers" test button and its now-dead imports.

Builders are the single choke point; both composers route through them under a `try/catch`, so a malformed reading never reaches the API. Renderer is intentionally untouched (still shows the canonical JSON) — renderer cards for all 7 types are a follow-up.

Design: `docs/plans/2026-07-17-thread-message-types-design.md`

## Test Plan
- [x] `node services/messageTypes.test.cjs` — valid location/metric deep-equal the canonical objects; out-of-range/non-number inputs throw
- [x] All touched files parse under `babel-preset-expo`
- [ ] Drive the thread screen: tap Location + Battery, confirm POST bodies are canonical `{type,version,payload}` and the Random Numbers button is gone

> Stacked on #45 (base: `feature/expo-sdk-upgrade`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)